### PR TITLE
fix(worker): return 400 on malformed URL instead of throwing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,12 @@ export default {
       return withSecurityHeaders(new Response("Method Not Allowed", { status: 405, headers: { Allow: "GET, HEAD" } }));
     }
 
-    const url = new URL(request.url);
+    let url: URL;
+    try {
+      url = new URL(request.url);
+    } catch {
+      return withSecurityHeaders(new Response("Bad Request", { status: 400 }));
+    }
     const pathname = url.pathname.replace(/\/+/g, "/").replace(/\/$/, "") || "/";
 
     if (pathname === "/install") {


### PR DESCRIPTION
## Summary

- `new URL(request.url)` in `src/index.ts` can throw a `TypeError` when the incoming request URL is malformed
- Without a try-catch, the worker crashes with an unhandled exception rather than returning a proper error response
- This PR wraps the constructor in a try-catch and returns a `400 Bad Request` (with `withSecurityHeaders()` applied) on failure

## Change

```diff
-    const url = new URL(request.url);
-    const pathname = url.pathname.replace(/\/+/g, "/").replace(/\/$/, "") || "/";
+    let url: URL;
+    try {
+      url = new URL(request.url);
+    } catch {
+      return withSecurityHeaders(new Response("Bad Request", { status: 400 }));
+    }
+    const pathname = url.pathname.replace(/\/+/g, "/").replace(/\/$/, "") || "/";
```

Minimal change — no restructuring, no new helpers.

Closes #22.

## Test plan

- [ ] Deploy to a Cloudflare Workers preview environment
- [ ] Send a request with a malformed URL (e.g. via a raw TCP client or a proxy that injects bad URLs)
- [ ] Confirm the worker responds with `HTTP 400 Bad Request` and the standard security headers (`X-Frame-Options`, `Strict-Transport-Security`, etc.)
- [ ] Confirm normal requests (`/`, `/install`, unknown paths) still behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)