### PR TITLE
fix: deduplicate formatSats helper (closes #42 finding 2)

### DIFF
--- a/src/components/stats-bar.tsx
+++ b/src/components/stats-bar.tsx
@@ -34,12 +34,6 @@ function useCountUp(target: number, duration = 1500) {
   return { value, ref };
 }
 
-function formatSats(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}m`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
-  return String(n);
-}
-
 interface StatsBarProps {
   sbtcBalance: string;
 }


### PR DESCRIPTION
## Summary

- Removed the duplicate `formatSats` function from `src/components/stats-bar.tsx` (lines 37-41)
- The canonical copy lives in `src/lib/sbtc.ts` (lines 25-29) and is already imported by `page.tsx`
- The copy in `stats-bar.tsx` was dead code — defined but never called within that file

## Context

Addresses **finding #2** from issue #42: `formatSats` was duplicated across two files with identical implementations.

## Test plan

- [ ] Verify the site builds without errors (`npm run build`)
- [ ] Confirm stats-bar still renders correctly (it never used `formatSats` internally)
- [ ] Confirm the sBTC balance display on the homepage still works (imports from `@/lib/sbtc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)